### PR TITLE
Feature slice indexing

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -21,6 +21,7 @@ const (
 	airlinesPath = "test/data/airlines.json"
 	todosPath    = "test/data/todos.json"
 	earthquakes  = "test/data/earthquakes.json"
+	booksPath    = "test/data/books.json"
 )
 
 type TodoModel struct {
@@ -1363,5 +1364,28 @@ func TestCompareDocumentFields(t *testing.T) {
 			cancelled := doc.Get("Statistics.Flights.Cancelled").(float64)
 			require.Greater(t, diverted, cancelled)
 		}
+	})
+}
+
+func TestSliceIndexing(t *testing.T) {
+	runCloverTest(t, booksPath, nil, func(t *testing.T, db *c.DB) {
+		docs, err := db.Query("books").Where(c.Field("title").Eq("A Study in Scarlet")).FindAll()
+		require.NoError(t, err)
+		d0 := docs[0]
+
+		docs, err = db.Query("books").Where(c.Field("title").Eq("The Hound of The Baskervilles")).FindAll()
+		require.NoError(t, err)
+		d1 := docs[0]
+
+		require.Equal(t, "Scotland", d0.Get("authors.0.bio.born"))
+		require.Equal(t, float64(1859), d1.Get("authors.0.bio.year"))
+		require.Equal(t, "Sir Arthur Conan Doyle", d1.Get("authors.0.name"))
+		require.Equal(t, "Crime", d1.Get("genre.1"))
+		require.Equal(t, "Detective Fiction", d0.Get("genre.0"))
+		require.Nil(t, d1.Get("genre.10"))
+		require.Nil(t, d1.Get("genre.first"))
+		require.Nil(t, d1.Get("authors.name"))
+		require.Equal(t, "The final problem", d0.Get("authors.0.bio.best_sellers.0.2"))
+		require.Nil(t,  d1.Get("authors.0.bio.best_sellers.0"))
 	})
 }

--- a/db_test.go
+++ b/db_test.go
@@ -1386,6 +1386,6 @@ func TestSliceIndexing(t *testing.T) {
 		require.Nil(t, d1.Get("genre.first"))
 		require.Nil(t, d1.Get("authors.name"))
 		require.Equal(t, "The final problem", d0.Get("authors.0.bio.best_sellers.0.2"))
-		require.Nil(t,  d1.Get("authors.0.bio.best_sellers.0"))
+		require.Nil(t, d1.Get("authors.0.bio.best_sellers.0"))
 	})
 }

--- a/document.go
+++ b/document.go
@@ -77,10 +77,10 @@ func lookupField(name string, fieldMap map[string]interface{}, force bool) (map[
 		if isSlice {
 			if i < end-1 {
 				v, increment := lookupSliceField(fields[i+1:], 2, s)
-				if m, isMap := v.(map[string]interface{}); isMap {
-					currMap = m
-				} else if v == nil {
+				if v == nil {
 					return nil, nil, ""
+				} else if m, isMap := v.(map[string]interface{}); isMap {
+					currMap = m
 				} else {
 					f = v
 				}

--- a/document.go
+++ b/document.go
@@ -49,6 +49,7 @@ func (doc *Document) Copy() *Document {
 	}
 }
 
+// force tells that if we did not finding anything we should create
 func lookupField(name string, fieldMap map[string]interface{}, force bool) (map[string]interface{}, interface{}, string) {
 	fields := strings.Split(name, ".")
 
@@ -76,7 +77,7 @@ func lookupField(name string, fieldMap map[string]interface{}, force bool) (map[
 		s, isSlice := f.([]interface{})
 		if isSlice {
 			if i < end-1 {
-				v, increment := lookupSliceField(fields[i+1:], 2, s)
+				v, increment := lookupSliceField(fields[i+1:], 1, s)
 				if v == nil {
 					return nil, nil, ""
 				} else if m, isMap := v.(map[string]interface{}); isMap {
@@ -86,7 +87,6 @@ func lookupField(name string, fieldMap map[string]interface{}, force bool) (map[
 				}
 
 				i += increment
-				continue
 			}
 		} else if i < end-1 {
 			currMap = m

--- a/document.go
+++ b/document.go
@@ -49,7 +49,6 @@ func (doc *Document) Copy() *Document {
 	}
 }
 
-// force tells that if we did not finding anything we should create
 func lookupField(name string, fieldMap map[string]interface{}, force bool) (map[string]interface{}, interface{}, string) {
 	fields := strings.Split(name, ".")
 

--- a/test/data/books.json
+++ b/test/data/books.json
@@ -1,0 +1,38 @@
+[
+    {
+        "title": "A Study in Scarlet",
+        "publisher": "Ward Lock & Co",
+        "genre": ["Detective Fiction", "Crime"],
+        "authors": [
+            {
+                "name": "Sir Arthur Conan Doyle",
+                "bio": {
+                    "born": "Scotland",
+                    "year": 1859,
+                    "best_sellers": [
+                        [
+                            "The Hound of the Baskerville",
+                            "The Adventure of the Speckled Band",
+                            "The final problem"
+                        ]
+                    ]
+                }
+            }
+        ]
+    },
+    {
+        "title": "The Hound of The Baskervilles",
+        "publisher": "George Newnes Ltd",
+        "genre": ["Detective Fiction", "Crime"],
+        "authors": [
+            {
+                "name": "Sir Arthur Conan Doyle",
+                "bio": {
+                    "born": "Scotland",
+                    "year": 1859,
+                    "best_sellers": []
+                }
+            }
+        ]
+    }
+]


### PR DESCRIPTION
I had to change the way the loop was done so that I could "advance" the fields whenever we hit a slice field (not sure if that was the best approach though, I was trying not to change the function so much).

Basically, every time we find a slice field, we step into lookupSliceField and do the indexing, returning the value found (after indexing) and the correct number of increments the control loop variable should do (aka skip the indexing fields in the current loop).

I also needed to add a books.json file so that I could cover indexing.