### PR TITLE
Resolve #64 (Allow to discover available fields for a document)

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -1136,25 +1136,25 @@ func TestDocumentUnmarshal(t *testing.T) {
 	})
 }
 
-func TestDocumentGetAll(t *testing.T) {
+func TestDocumentToMap(t *testing.T) {
 	runCloverTest(t, airlinesPath, nil, func(t *testing.T, db *c.DB) {
 		doc, err := db.Query("airlines").Where(c.Field("Airport.Code").Eq("CLT")).FindFirst()
 		require.NoError(t, err)
 		require.NotNil(t, doc)
 		
-		fields := doc.GetAll()
+		fields := doc.ToMap()
 		require.Equal(t, fields["Airport"].(map[string]interface{})["Code"], "CLT")
 		require.Equal(t, len(fields), 4)		
 	})
 }
 
-func TestDocumentGetFields(t *testing.T) {
+func TestDocumentFields(t *testing.T) {
 	runCloverTest(t, airlinesPath, nil, func(t *testing.T, db *c.DB) {
 		doc, err := db.Query("airlines").Where(c.Field("Airport.Code").Eq("CLT")).FindFirst()
 		require.NoError(t, err)
 		require.NotNil(t, doc)
 		
-		keys := doc.GetKeys()
+		keys := doc.Fields()
 		require.Equal(t, len(keys), 25)
 		require.Contains(t, keys, "Airport.Code")
 		require.Contains(t, keys, "# of Delays.National Aviation System")		

--- a/db_test.go
+++ b/db_test.go
@@ -1136,6 +1136,31 @@ func TestDocumentUnmarshal(t *testing.T) {
 	})
 }
 
+func TestDocumentGetAll(t *testing.T) {
+	runCloverTest(t, airlinesPath, nil, func(t *testing.T, db *c.DB) {
+		doc, err := db.Query("airlines").Where(c.Field("Airport.Code").Eq("CLT")).FindFirst()
+		require.NoError(t, err)
+		require.NotNil(t, doc)
+		
+		fields := doc.GetAll()
+		require.Equal(t, fields["Airport"].(map[string]interface{})["Code"], "CLT")
+		require.Equal(t, len(fields), 4)		
+	})
+}
+
+func TestDocumentGetFields(t *testing.T) {
+	runCloverTest(t, airlinesPath, nil, func(t *testing.T, db *c.DB) {
+		doc, err := db.Query("airlines").Where(c.Field("Airport.Code").Eq("CLT")).FindFirst()
+		require.NoError(t, err)
+		require.NotNil(t, doc)
+		
+		keys := doc.GetKeys()
+		require.Equal(t, len(keys), 25)
+		require.Contains(t, keys, "Airport.Code")
+		require.Contains(t, keys, "# of Delays.National Aviation System")		
+	})
+}
+
 func TestListCollections(t *testing.T) {
 	runCloverTest(t, todosPath, &TodoModel{}, func(t *testing.T, db *c.DB) {
 		collections, err := db.ListCollections()

--- a/db_test.go
+++ b/db_test.go
@@ -1137,28 +1137,45 @@ func TestDocumentUnmarshal(t *testing.T) {
 }
 
 func TestDocumentToMap(t *testing.T) {
-	runCloverTest(t, airlinesPath, nil, func(t *testing.T, db *c.DB) {
-		doc, err := db.Query("airlines").Where(c.Field("Airport.Code").Eq("CLT")).FindFirst()
-		require.NoError(t, err)
-		require.NotNil(t, doc)
-		
-		fields := doc.ToMap()
-		require.Equal(t, fields["Airport"].(map[string]interface{})["Code"], "CLT")
-		require.Equal(t, len(fields), 4)		
+	doc := c.NewDocumentOf(map[string]interface{}{
+		"f_1": map[string]interface{}{
+			"f_1_1": float64(0),
+			"f_1_2": "aString",
+		},
+		"f_2": map[string]interface{}{
+			"f_2_1": float64(1),
+			"f_2_2": "aString",			
+		},
+		"f_3": int64(42),		
 	})
+
+	fields := doc.ToMap()
+	require.Equal(t, float64(0), fields["f_1"].(map[string]interface{})["f_1_1"])
+	require.Equal(t, "aString", fields["f_2"].(map[string]interface{})["f_2_2"])
+	require.Equal(t, int64(42), fields["f_3"])
+	require.Equal(t, 3, len(fields))
 }
 
 func TestDocumentFields(t *testing.T) {
-	runCloverTest(t, airlinesPath, nil, func(t *testing.T, db *c.DB) {
-		doc, err := db.Query("airlines").Where(c.Field("Airport.Code").Eq("CLT")).FindFirst()
-		require.NoError(t, err)
-		require.NotNil(t, doc)
-		
-		keys := doc.Fields()
-		require.Equal(t, len(keys), 25)
-		require.Contains(t, keys, "Airport.Code")
-		require.Contains(t, keys, "Statistics.# of Delays.National Aviation System")		
+	doc := c.NewDocumentOf(map[string]interface{}{
+		"f_1": map[string]interface{}{
+			"f_1_1": float64(0),
+			"f_1_2": "aString",
+		},
+		"f_2": map[string]interface{}{
+			"f_2_1": float64(1),
+			"f_2_2": "aString",			
+		},
+		"f_3": int64(42),		
 	})
+
+	keys := doc.Fields()	
+	require.Contains(t, keys, "f_1.f_1_1")
+	require.Contains(t, keys, "f_1.f_1_2")
+	require.Contains(t, keys, "f_2.f_2_1")
+	require.Contains(t, keys, "f_2.f_2_2")
+	require.Contains(t, keys, "f_3")
+	require.Equal(t, 5, len(keys))
 }
 
 func TestListCollections(t *testing.T) {

--- a/db_test.go
+++ b/db_test.go
@@ -1157,7 +1157,7 @@ func TestDocumentFields(t *testing.T) {
 		keys := doc.Fields()
 		require.Equal(t, len(keys), 25)
 		require.Contains(t, keys, "Airport.Code")
-		require.Contains(t, keys, "# of Delays.National Aviation System")		
+		require.Contains(t, keys, "Statistics.# of Delays.National Aviation System")		
 	})
 }
 

--- a/document.go
+++ b/document.go
@@ -109,7 +109,7 @@ func (doc *Document) ToMap() map[string]interface{} {
 	return copyMap(doc.fields)
 }
 
-// GetKeys returns a slice of all available field names in the document. Nested fields are represented using dot notation (in such case parent fields are not represented standalone). There is no guarantee on the order.
+// Fields returns a slice of all available field names in the document. Nested fields are represented using dot notation (in such case parent fields are not represented standalone). There is no guarantee on the order.
 func (doc *Document) Fields() []string {
 	return getAllKeys(doc.fields)
 }

--- a/document.go
+++ b/document.go
@@ -105,26 +105,13 @@ func (doc *Document) SetAll(values map[string]interface{}) {
 }
 
 // GetAll returns a map of all available fields in the document. Nested fields are represented by sub-maps. This is a deep copy, but values are note cloned.
-func (doc *Document) GetAll() map[string]interface{} {
+func (doc *Document) ToMap() map[string]interface{} {
 	return copyMap(doc.fields)
 }
 
 // GetKeys returns a slice of all available field names in the document. Nested fields are represented using dot notation (in such case parent fields are not represented standalone). There is no guarantee on the order.
-func (doc *Document) GetKeys() []string {
+func (doc *Document) Fields() []string {
 	return getKeysRecursive(doc.fields, "")
-}
-
-func getKeysRecursive(fields map[string]interface{}, prefix string) []string {
-	result := []string{}
-	for key, value := range fields {	
-		subMap, isMap := value.(map[string]interface{})
-		if isMap {
-			result = append(result, getKeysRecursive(subMap, key + ".")...)
-		} else {
-			result = append(result, prefix + key)
-		}
-	}
-	return result
 }
 
 // Unmarshal stores the document in the value pointed by v.

--- a/document.go
+++ b/document.go
@@ -109,7 +109,7 @@ func (doc *Document) GetAll() map[string]interface{} {
 	return copyMap(doc.fields)
 }
 
-// GetKeys returns a slice of all available field names in the document. Nested fields are represented using dot notation (in such case parent fields are not represented standalone).
+// GetKeys returns a slice of all available field names in the document. Nested fields are represented using dot notation (in such case parent fields are not represented standalone). There is no guarantee on the order.
 func (doc *Document) GetKeys() []string {
 	return getKeysRecursive(doc.fields, "")
 }

--- a/document.go
+++ b/document.go
@@ -111,7 +111,7 @@ func (doc *Document) ToMap() map[string]interface{} {
 
 // GetKeys returns a slice of all available field names in the document. Nested fields are represented using dot notation (in such case parent fields are not represented standalone). There is no guarantee on the order.
 func (doc *Document) Fields() []string {
-	return getKeysRecursive(doc.fields, "")
+	return getAllKeys(doc.fields)
 }
 
 // Unmarshal stores the document in the value pointed by v.

--- a/document.go
+++ b/document.go
@@ -104,6 +104,29 @@ func (doc *Document) SetAll(values map[string]interface{}) {
 	}
 }
 
+// GetAll returns a map of all available fields in the document. Nested fields are represented by sub-maps. This is a deep copy, but values are note cloned.
+func (doc *Document) GetAll() map[string]interface{} {
+	return copyMap(doc.fields)
+}
+
+// GetKeys returns a slice of all available field names in the document. Nested fields are represented using dot notation (in such case parent fields are not represented standalone).
+func (doc *Document) GetKeys() []string {
+	return getKeysRecursive(doc.fields, "")
+}
+
+func getKeysRecursive(fields map[string]interface{}, prefix string) []string {
+	result := []string{}
+	for key, value := range fields {	
+		subMap, isMap := value.(map[string]interface{})
+		if isMap {
+			result = append(result, getKeysRecursive(subMap, key + ".")...)
+		} else {
+			result = append(result, prefix + key)
+		}
+	}
+	return result
+}
+
 // Unmarshal stores the document in the value pointed by v.
 func (doc *Document) Unmarshal(v interface{}) error {
 	return encoding.Convert(doc.fields, v)

--- a/util.go
+++ b/util.go
@@ -64,3 +64,17 @@ func toInt64(v interface{}) int64 {
 	}
 	panic("not a number")
 }
+
+// Returns a flat list of keys of the map. Recurses on sub-maps, in which case the dot notation is used (ex. a.b.c)
+func getKeysRecursive(fields map[string]interface{}, prefix string) []string {
+	result := []string{}
+	for key, value := range fields {	
+		subMap, isMap := value.(map[string]interface{})
+		if isMap {
+			result = append(result, getKeysRecursive(subMap, key + ".")...)
+		} else {
+			result = append(result, prefix + key)
+		}
+	}
+	return result
+}

--- a/util.go
+++ b/util.go
@@ -65,15 +65,18 @@ func toInt64(v interface{}) int64 {
 	panic("not a number")
 }
 
-// Returns a flat list of keys of the map. Recurses on sub-maps, in which case the dot notation is used (ex. a.b.c)
-func getKeysRecursive(fields map[string]interface{}, prefix string) []string {
+// Returns a flat list of all keys of the map, including sub-maps, in which case the dot notation is used (ex. a.b.c)
+func getAllKeys(fields map[string]interface{}) []string {
 	result := []string{}
-	for key, value := range fields {	
+	for key, value := range fields {
 		subMap, isMap := value.(map[string]interface{})
 		if isMap {
-			result = append(result, getKeysRecursive(subMap, key + ".")...)
+			subFields := getAllKeys(subMap)
+			for _, subKey := range subFields {
+				result = append(result, key + "." + subKey)
+			}
 		} else {
-			result = append(result, prefix + key)
+			result = append(result, key)
 		}
 	}
 	return result


### PR DESCRIPTION
@ostafen, just wondering if what I assume are "reserved" fields like "__id" should be included by GetKeys(). Currently they are, but I think they might preferably not. In such case, is it clearly documented that field names starting with "_" are supposed to be reserved ? Let me know