### PR TITLE
Go 1.16 compatibility changes

### DIFF
--- a/db_test.go
+++ b/db_test.go
@@ -13,8 +13,9 @@ import (
 	"testing"
 	"time"
 
-	c "github.com/ostafen/clover"
 	"github.com/stretchr/testify/require"
+
+	c "github.com/ostafen/clover"
 )
 
 const (
@@ -855,9 +856,9 @@ func TestTimeRangeQuery(t *testing.T) {
 		require.Len(t, docs, n)
 
 		for _, doc := range docs {
-			date := doc.Get("completed_date")
-			require.GreaterOrEqual(t, date, start)
-			require.Less(t, date, end)
+			date := doc.Get("completed_date").(time.Time)
+			require.Positive(t, date.Sub(start))
+			require.Negative(t, date.Sub(end))
 		}
 	})
 }

--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -35,7 +35,7 @@ func isEmptyValue(v reflect.Value) bool {
 		return v.Uint() == 0
 	case reflect.Float32, reflect.Float64:
 		return v.Float() == 0
-	case reflect.Interface, reflect.Pointer:
+	case reflect.Interface, reflect.Ptr:
 		return v.IsNil()
 	}
 	return false
@@ -47,7 +47,7 @@ func normalizeStruct(structValue reflect.Value) (map[string]interface{}, error) 
 		fieldType := structValue.Type().Field(i)
 		fieldValue := structValue.Field(i)
 
-		if fieldType.IsExported() {
+		if fieldType.PkgPath == "" {
 			fieldName := fieldType.Name
 
 			cloverTag := fieldType.Tag.Get("clover")
@@ -184,7 +184,7 @@ func rename(fields map[string]interface{}, v interface{}) map[string]interface{}
 }
 
 func getElemType(rt reflect.Type) reflect.Type {
-	for rt.Kind() == reflect.Pointer {
+	for rt.Kind() == reflect.Ptr {
 		rt = rt.Elem()
 	}
 	return rt


### PR DESCRIPTION
Despite a claim to work with Go 1.13+ it does not compile with Go 1.16.5:
* reflect.Pointer not available
* reflect.IsExported() not available
* time.Time not comparable with testify/require