### PR TITLE
fix: anonymous field will not be Unmarshalled to struct

### DIFF
--- a/encoding/encoding.go
+++ b/encoding/encoding.go
@@ -61,7 +61,17 @@ func normalizeStruct(structValue reflect.Value) (map[string]interface{}, error) 
 				if err != nil {
 					return nil, err
 				}
-				m[fieldName] = normalized
+				if !fieldType.Anonymous {
+					m[fieldName] = normalized
+				} else {
+					if normalizedMap, ok := normalized.(map[string]interface{}); ok {
+						for k, v := range normalizedMap {
+							m[k] = v
+						}
+					} else {
+						m[fieldName] = normalized
+					}
+				}
 			}
 		}
 	}

--- a/encoding/encoding_test.go
+++ b/encoding/encoding_test.go
@@ -7,7 +7,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type BaseModel struct {
+	ID string `clover:""`
+}
+
 type TestStruct struct {
+	BaseModel
 	IntField    int                    `clover:"int,omitempty"`
 	UintField   uint                   `clover:"uint,omitempty"`
 	StringField string                 `clover:",omitempty"`
@@ -21,11 +26,14 @@ type TestStruct struct {
 }
 
 func TestNormalize(t *testing.T) {
-	date := time.Date(2020, 01, 1, 0, 0, 0, 0, time.UTC)
+	date := time.Date(2020, 0o1, 1, 0, 0, 0, 0, time.UTC)
 
 	var x int = 100
 
 	s := &TestStruct{
+		BaseModel: BaseModel{
+			ID: "UID",
+		},
 		TimeField:   date,
 		IntField:    10,
 		FloatField:  0.1,
@@ -50,9 +58,13 @@ func TestNormalize(t *testing.T) {
 	require.Nil(t, m["uint"]) // testing omitempty
 	require.Equal(t, m["IntPtr"], int64(100))
 
+	require.Equal(t, m["ID"], "UID")
+
 	s1 := &TestStruct{}
 	err = Convert(m, s1)
 	require.NoError(t, err)
+
+	require.Equal(t, s1.ID, "UID")
 
 	require.Equal(t, s, s1)
 


### PR DESCRIPTION
``` go
type BasicModel struct {
	ID string `clover:"_id" json:"_id"`
}

type User struct {
	BasicModel
	Name string `clover:"name" json:"name"`
}

func TestAnonymousField(t *testing.T) {
	user := &User{
		Name: "Alice",
	}
	user.ID = "UUUU-UUUU-UUUU"

	doc := clover.NewDocumentOf(user)

	docMap := map[string]interface{}{}
	doc.Unmarshal(&docMap)

	buff, _ := json.MarshalIndent(docMap, "", "  ")

	fmt.Println(string(buff))
	/*
		{
		  "BasicModel": {
		    "_id": "UUUU-UUUU-UUUU"
		  },
		  "name": "Alice"
		}
	*/

	user2 := &User{}

	doc.Unmarshal(user2)

	fmt.Println(user2.ID) // "", empty
}

```

With my commit, the buff will be like :

``` json
{
  "_id": "UUUU-UUUU-UUUU",
  "name": "Alice"
}
```
