### PR TITLE
chore: don't startGC when open database error

### DIFF
--- a/storage_impl.go
+++ b/storage_impl.go
@@ -68,13 +68,16 @@ func (s *storageImpl) Open(path string, c *Config) error {
 	}
 
 	db, err := badger.Open(badger.DefaultOptions(path).WithLoggingLevel(badger.ERROR).WithInMemory(c.InMemory))
+	if err != nil {
+		return err
+	}
 
 	s.db = db
 	s.conf = c
 
 	s.startGC()
 
-	return err
+	return nil
 }
 
 type collectionMetadata struct {


### PR DESCRIPTION
When open database error, but startGC already call, if this error ignored, will cause startGC panic(db is nil) on next tick.