### PR TITLE
Implement batch insert

### DIFF
--- a/db.go
+++ b/db.go
@@ -77,7 +77,7 @@ func (db *DB) CreateCollectionByQuery(name string, q *query.Query) error {
 	if len(docs) == 0 { // just an empty collection
 		return nil
 	} else {
-		return db.Insert(name, docs...)
+		return db.InsertBatch(name, docs...)
 	}
 }
 

--- a/store/bbolt/bbolt.go
+++ b/store/bbolt/bbolt.go
@@ -41,6 +41,10 @@ func (store *boltStore) createRootBucketIfNotExists() error {
 	return tx.Commit()
 }
 
+func (store *boltStore) BeginWithUpdateBatch() (store.UpdateTx, error) {
+	return store.Begin(true) // not implemented, temporarily use the normal update transaction
+}
+
 func (store *boltStore) Begin(update bool) (store.Tx, error) {
 	tx, err := store.db.Begin(update)
 	return &boltTx{Tx: tx}, err

--- a/store/store.go
+++ b/store/store.go
@@ -2,16 +2,22 @@ package store
 
 type Store interface {
 	Begin(update bool) (Tx, error)
+	BeginWithUpdateBatch() (UpdateTx, error)
 	Close() error
 }
 
-type Tx interface {
+// updateTx only supports update and delete operations
+type UpdateTx interface {
 	Set(key, value []byte) error
-	Get(key []byte) ([]byte, error)
 	Delete(key []byte) error
-	Cursor(forward bool) (Cursor, error)
 	Commit() error
 	Rollback() error
+}
+
+type Tx interface {
+	UpdateTx
+	Get(key []byte) ([]byte, error)
+	Cursor(forward bool) (Cursor, error)
 }
 
 type Cursor interface {


### PR DESCRIPTION
Use badgerDb's WriteBatch API to implement batch insertion. However, batch insert does not support uniqueness checks on data.