### PR TITLE
[FIX] Log Fatalf in badger GC routine.

### DIFF
--- a/store/badger/badger.go
+++ b/store/badger/badger.go
@@ -139,7 +139,7 @@ func (store *badgerStore) startGC() {
 			case <-ticker.C:
 				err := store.db.RunValueLogGC(GCDiscardRatio)
 				if err != nil && errors.Is(err, badger.ErrNoRewrite) {
-					log.Fatalf("RunValueLogGC(): %s\n", err.Error())
+					log.Printf("RunValueLogGC(): %s\n", err.Error())
 				}
 			}
 		}


### PR DESCRIPTION
Solves #145.

Changed log Fatalf to Printf in badger GC routine to avoid exiting application when ErrNoRewrite occurs.