### PR TITLE
Fixes #151 

### DIFF
--- a/internal/encoding.go
+++ b/internal/encoding.go
@@ -168,10 +168,13 @@ func Normalize(value interface{}) (interface{}, error) {
 	return nil, fmt.Errorf("invalid dtype %s", rType.Name())
 }
 
-func createRenameMap(rv reflect.Value) map[string]string {
-	renameMap := make(map[string]string)
+func createRenameMap(rv reflect.Value, renameMap map[string]string) map[string]string {
 	for i := 0; i < rv.NumField(); i++ {
 		fieldType := rv.Type().Field(i)
+		if fieldType.Anonymous {
+			createRenameMap(rv.Field(i), renameMap)
+			continue
+		}
 
 		renameTo := fieldType.Name
 		renameFrom := fieldType.Name
@@ -205,7 +208,7 @@ func rename(fields map[string]interface{}, v interface{}) map[string]interface{}
 		return nil
 	}
 
-	renameMap := createRenameMap(rv)
+	renameMap := createRenameMap(rv, make(map[string]string))
 	m := make(map[string]interface{})
 	for key, value := range fields {
 		renamedFieldName := renameMap[key]

--- a/internal/encoding_test.go
+++ b/internal/encoding_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 type BaseModel struct {
-	ID string `clover:""`
+	ID string `clover:"_id" json:"cloverId"`
 }
 
 type TestStruct struct {
@@ -69,7 +69,7 @@ func TestNormalize(t *testing.T) {
 
 	require.Nil(t, m["uint"]) // testing omitempty
 	require.Equal(t, m["IntPtr"], int64(100))
-	require.Equal(t, m["ID"], "UID")
+	require.Equal(t, m["_id"], "UID")
 
 	s1 := &TestStruct{}
 	err = Convert(m, s1)


### PR DESCRIPTION
Add a recursive call to `createRenameMap` in the encoding to handle fields of embedded structs.